### PR TITLE
feat: 次のカフェイン摂取時間の表示機能 (#20)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,10 @@ import TopBackButton from "@/components/TopBackButton";
 import Chart from "@/components/Chart";
 import React, { useState } from "react";
 import { calcFocusData, FocusDataPoint } from "@/lib/calcFocusData";
+import RecommendedPlanList from "../components/NextCaffeineTime";
+
+// モックデータの型定義(APIの実装が終わり次第削除予定)
+import type { Recommendation } from "../components/NextCaffeineTime";
 
 const HomePage: React.FC = () => {
   const [bed_time, setBedTime] = useState("");
@@ -18,10 +22,10 @@ const HomePage: React.FC = () => {
 
   // エラーメッセージ
   const [error, setError] = useState("");
-  
+
   // API読み込み状態
   const [isLoading, setIsLoading] = useState(false);
-  
+
   // グラフデータの状態管理
   const [chartData, setChartData] = useState<FocusDataPoint[]>([]);
 
@@ -51,12 +55,20 @@ const HomePage: React.FC = () => {
     return true;
   };
 
+  // モックデータ(APIの実装が終わり次第削除予定)
+  const recommendations: Recommendation[] = [
+    { time: "08:00", item: "ドリップコーヒー", amount: "1杯" },
+    { time: "14:00", item: "エナジードリンク", amount: "半分" },
+    { time: "20:30", item: "カフェラテ", amount: "1杯" },
+    { time: "23:00", item: "カフェインレスコーヒー", amount: "1杯" },
+  ];
+
   const handleGeneratePlan = async () => {
     if (!isValid()) {
       setError("集中時間・睡眠時間を入力してください");
       return;
     }
-    
+
     setError("");
     setIsLoading(true);
 
@@ -80,25 +92,24 @@ const HomePage: React.FC = () => {
       }
 
       const result = await response.json();
-      
+
       // APIレスポンスからグラフデータを更新
       if (result.data) {
         setChartData(result.data);
       } else {
         // フォールバック：APIレスポンスが期待した形式でない場合
         // 最初の集中時間を使用してグラフデータを生成
-        const firstFocusPeriod = focusPeriods.find(p => p.start && p.end);
+        const firstFocusPeriod = focusPeriods.find((p) => p.start && p.end);
         if (firstFocusPeriod) {
           const fallbackData = calcFocusData(
-            wake_time, 
-            bed_time, 
-            firstFocusPeriod.start, 
-            firstFocusPeriod.end
+            wake_time,
+            bed_time,
+            firstFocusPeriod.start,
+            firstFocusPeriod.end,
           );
           setChartData(fallbackData);
         }
       }
-
     } catch (error) {
       console.error("エラーが発生しました:", error);
       setError("プラン生成中にエラーが発生しました");
@@ -116,7 +127,10 @@ const HomePage: React.FC = () => {
           <div className="w-full max-w-2xl flex justify-center">
             <UnityModel />
           </div>
-
+          {/* 次のコーヒー摂取時間 */}
+          <div className="w-full max-w-4xl mx-auto px-4 mt-8">
+            <RecommendedPlanList recommendations={recommendations} />
+          </div>
           <main className="flex flex-col items-center flex-1 w-full max-w-2xl mx-auto">
             {/* 睡眠セクション */}
             <section className="w-full mb-8 mt-8">

--- a/src/components/NextCaffeineTime.tsx
+++ b/src/components/NextCaffeineTime.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+
+export interface Recommendation {
+  time: string; // "08:00"
+  item: string; // "ドリップコーヒー"
+  amount: string; // 例: 1杯
+}
+
+/**
+ * 現在時刻から最も近い順でローテーション表示
+ * 例：現在時刻が15:00の場合
+ * 16:00→20:00→08:00→12:00
+ */
+function getSortedByCurrentTime(
+  recommendations: Recommendation[],
+  now: Date,
+): Recommendation[] {
+  // "HH:MM"→分に変換
+  const toMinutes = (t: string) => {
+    const [h, m] = t.split(":").map(Number);
+    return h * 60 + m;
+  };
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+
+  // 今以降→今より前、で結合
+  const after = recommendations.filter(
+    (rec) => toMinutes(rec.time) >= nowMinutes,
+  );
+  const before = recommendations.filter(
+    (rec) => toMinutes(rec.time) < nowMinutes,
+  );
+  // 昇順で並べてから、結合
+  const sortByTime = (a: Recommendation, b: Recommendation) =>
+    toMinutes(a.time) - toMinutes(b.time);
+  return [...after.sort(sortByTime), ...before.sort(sortByTime)];
+}
+
+export interface RecommendedPlanListProps {
+  recommendations: Recommendation[];
+}
+
+const RecommendedPlanList: React.FC<RecommendedPlanListProps> = ({
+  recommendations,
+}) => {
+  // 現在時刻でソート
+  const sorted = getSortedByCurrentTime(recommendations, new Date());
+
+  // ★次の1件だけを抽出
+  const nextRec = sorted.length > 0 ? sorted[0] : null;
+
+  return (
+    <div className="w-full max-w-2xl mx-auto flex flex-col gap-2">
+      {!nextRec && (
+        <div className="text-center text-gray-400 p-4">
+          推奨プランがありません
+        </div>
+      )}
+      {nextRec && (
+        <div className="bg-white rounded-2xl shadow-md px-3 py-3 flex flex-col gap-2 border-l-4 border-blue-400 mx-auto w-full max-w-xs sm:max-w-sm text-center">
+          {/* 時間 */}
+          <div className="flex items-center justify-center gap-1 w-full">
+            <span className="text-xs text-gray-400">次の摂取は</span>
+            <span className="text-blue-600 font-bold text-lg sm:text-xl">
+              {nextRec.time}
+            </span>
+            <span className="text-xs text-gray-400">です</span>
+          </div>
+          {/* 内容 */}
+          <div className="flex items-center justify-center gap-1 w-full">
+            <span className="text-gray-800 font-semibold text-sm">
+              {nextRec.item}
+            </span>
+            <span className="text-gray-500 text-sm">{nextRec.amount}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecommendedPlanList;


### PR DESCRIPTION
## 概要
次のカフェイン摂取時間をカード形式で表示する機能を追加しました。

## 変更内容
- APIから取得されるデータを想定し、モックデータを `src/app/page.tsx` に定義
- 上記データをもとに、次の摂取タイミングを示すカードUIを表示
- レスポンシブ対応（スマホでも表示確認済み）

## 補足
- APIの実装が完了し次第、モックデータは削除してください。

## 関連Issue
- #20
