### PR TITLE
feat: カフェイン摂取を記録する折り畳み式フォームを作成 (#19)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
+import React, { useState } from "react";
 import BlueButton from "../components/BlueButton";
 import UnityModel from "../components/UnityModel";
 import TopBackButton from "@/components/TopBackButton";
 import Chart from "@/components/Chart";
-import React, { useState } from "react";
 import { calcFocusData, FocusDataPoint } from "@/lib/calcFocusData";
 import RecommendedPlanList from "../components/NextCaffeineTime";
+import CaffeineLogForm from "../components/CaffeineLogForm";
 
 // モックデータの型定義(APIの実装が終わり次第削除予定)
 import type { Recommendation } from "../components/NextCaffeineTime";
@@ -28,6 +29,9 @@ const HomePage: React.FC = () => {
 
   // グラフデータの状態管理
   const [chartData, setChartData] = useState<FocusDataPoint[]>([]);
+
+  // 摂取記録フォームの開閉state
+  const [isLogFormOpen, setIsLogFormOpen] = useState(false);
 
   // 集中時間の追加
   const addFocusPeriod = () =>
@@ -130,6 +134,29 @@ const HomePage: React.FC = () => {
           {/* 次のコーヒー摂取時間 */}
           <div className="w-full max-w-4xl mx-auto px-4 mt-8">
             <RecommendedPlanList recommendations={recommendations} />
+          </div>
+
+          {/* カフェイン摂取記録フォーム（タイトル＆開閉ボタン） */}
+          <div className="w-full max-w-2xl mx-auto my-8">
+            <div className="flex items-center mb-2">
+              {/* 1. 円形ボタン 2. 左側に配置 */}
+              <button
+                type="button"
+                className={`
+                  mr-3 w-8 h-8 flex items-center justify-center rounded-full 
+                  bg-blue-100 text-blue-600 hover:bg-blue-200 font-bold 
+                  transition text-xl
+                `}
+                onClick={() => setIsLogFormOpen((prev) => !prev)}
+                aria-label={isLogFormOpen ? "閉じる" : "開く"}
+              >
+                {isLogFormOpen ? "-" : "+"}
+              </button>
+              <h2 className="text-lg font-bold text-gray-800">
+                カフェイン摂取記録
+              </h2>
+            </div>
+            {isLogFormOpen && <CaffeineLogForm />}
           </div>
           <main className="flex flex-col items-center flex-1 w-full max-w-2xl mx-auto">
             {/* 睡眠セクション */}

--- a/src/components/CaffeineDrinkSelect.tsx
+++ b/src/components/CaffeineDrinkSelect.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import type { DrinkOption } from "../lib/caffeine-drink-options";
+
+// 親コンポーネントから受け取るpropsの型定義
+interface Props {
+  drinkOptions: DrinkOption[]; // 選択肢として表示するドリンクデータ一覧
+  drink: string; // 選択中の飲料名
+  mode: "preset" | "custom"; // 杯数or量(ml)の入力モード
+  setMode: (m: "preset" | "custom") => void; // 入力モード変更関数
+  cups: number | string; // 選択中の杯数
+  setCups: (n: number) => void; // 杯数変更関数
+  ml: number; // 量(ml)の値
+  setMl: (n: number) => void; // 量(ml)変更関数
+  onDrinkChange: (drink: string) => void; // 飲料選択変更ハンドラ
+}
+
+// カフェイン摂取飲料＋量選択UI
+const CaffeineDrinkSelect: React.FC<Props> = ({
+  drinkOptions,
+  drink,
+  mode,
+  setMode,
+  cups,
+  setCups,
+  ml,
+  setMl,
+  onDrinkChange,
+}) => {
+  // 現在選択中の飲料オブジェクト取得（未選択時は0番目）
+  const selected =
+    drinkOptions.find((d) => d.name === drink) || drinkOptions[0];
+  // 任意ml入力の可否
+  const enableCustom = selected.enableCustomMl !== false;
+
+  return (
+    <div className="flex flex-col gap-2 flex-1">
+      {/* 飲料名セレクトボックス */}
+      <div>
+        <label className="block text-sm text-gray-600 mb-1">飲料名</label>
+        <select
+          className="w-full px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900 placeholder-gray-400"
+          value={drink}
+          onChange={(e) => onDrinkChange(e.target.value)}
+        >
+          {/* 選択肢一覧を動的生成 */}
+          <option value="" disabled className="text-gray-400">
+            選択してください
+          </option>
+          {drinkOptions.map((opt) => (
+            <option key={opt.name} value={opt.name}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 摂取量の入力欄（プリセット or 任意ml） */}
+      <div>
+        <label className="block text-sm text-gray-600 mb-1">摂取量</label>
+        <div className="flex gap-2">
+          {/* 杯数 or 任意ml モード切替ボタン */}
+          <button
+            type="button"
+            className={`px-3 py-1 rounded-l-xl border ${mode === "preset" ? "bg-blue-500 text-white" : "bg-white text-blue-500 border-blue-400"}`}
+            onClick={() => setMode("preset")}
+          >
+            杯数
+          </button>
+          {enableCustom && (
+            <button
+              type="button"
+              className={`px-3 py-1 rounded-r-xl border-l-0 border ${mode === "custom" ? "bg-blue-500 text-white" : "bg-white text-blue-500 border-blue-400"}`}
+              onClick={() => setMode("custom")}
+            >
+              任意ml
+            </button>
+          )}
+        </div>
+
+        {/* 杯数入力（セレクトボックス） */}
+        {mode === "preset" ? (
+          <select
+            className="mt-2 w-full px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900 placeholder-gray-400"
+            value={cups}
+            onChange={(e) => setCups(Number(e.target.value))}
+          >
+            <option value="" disabled className="text-gray-400">
+              選択してください
+            </option>
+            {selected.cupPresets.map((n) => (
+              <option key={n} value={n}>
+                {n === 0.5 ? "半分" : `${n}杯`}
+              </option>
+            ))}
+          </select>
+        ) : (
+          // 任意ml入力
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="number"
+              min={10}
+              step={10}
+              className="w-28 px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900 placeholder-gray-400"
+              value={ml || ""}
+              onChange={(e) => setMl(Number(e.target.value))}
+              placeholder="入力してください"
+            />
+            <span className="text-gray-600">ml</span>
+          </div>
+        )}
+
+        {/* 杯数モードの時に1杯あたりmlを注記表示 */}
+        {mode === "preset" && (
+          <div className="text-xs text-gray-400 mt-1">
+            1杯 = {selected.defaultMlPerCup}ml
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CaffeineDrinkSelect;

--- a/src/components/CaffeineLogForm.tsx
+++ b/src/components/CaffeineLogForm.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { DRINK_OPTIONS, DrinkOption } from "../lib/caffeine-drink-options";
+import CaffeineDrinkSelect from "./CaffeineDrinkSelect";
+import CaffeineLogTable, { CaffeineLogEntry } from "./CaffeineLogTable";
+
+/**
+ * 飲料名と摂取量を入力するコンポーネント
+ *  飲料によって杯数の選択肢やカフェインの含有量が異なるため，これらをセットで管理する
+ */
+
+// ドリンク摂取量(ml)からカフェイン摂取量(mg)へ計算する関数
+function calcCaffeineMg(drink: DrinkOption, ml: number): number {
+  return Math.round((drink.caffeineMgPer100ml * ml) / 100);
+}
+
+// カフェイン摂取記録フォームのコンポーネント
+const CaffeineLogForm: React.FC = () => {
+  // フォームの入力状態（時間、飲料名、入力モード、杯数、ml）
+  const [time, setTime] = useState("");
+  const [drinkName, setDrinkName] = useState(DRINK_OPTIONS[0].name);
+  const [mode, setMode] = useState<"preset" | "custom">("preset");
+  const [cups, setCups] = useState(DRINK_OPTIONS[0].cupPresets[0]);
+  const [ml, setMl] = useState(DRINK_OPTIONS[0].defaultMlPerCup);
+
+  // 摂取履歴
+  const [logs, setLogs] = useState<CaffeineLogEntry[]>([]);
+
+  // 未入力項目ありメッセージ/登録完了メッセージ
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  // 現在選択中の飲料データを取得
+  const selectedDrink = DRINK_OPTIONS.find((d) => d.name === drinkName)!;
+  // 入力値から総摂取mlを計算（何杯or何mlのどちらで入力したかによって計算式が違う）
+  const totalMl =
+    mode === "preset"
+      ? Number(cups) * selectedDrink.defaultMlPerCup
+      : Number(ml);
+
+  // 飲料変更時に値をリセット
+  const handleDrinkChange = (next: string) => {
+    setDrinkName(next);
+    const found = DRINK_OPTIONS.find((d) => d.name === next)!;
+    setCups(found.cupPresets[0]);
+    setMl(found.defaultMlPerCup);
+    setMode("preset");
+  };
+
+  // 「追加」ボタン押下時に時間が未入力ならエラーメッセージ出力
+  const handleAddLog = () => {
+    if (!time) {
+      setError("摂取時間を入力してください"); //
+      setSuccess("");
+      return;
+    }
+    setError("");
+
+    // カフェイン量計算
+    const caffeineMg = calcCaffeineMg(selectedDrink, totalMl);
+
+    // ログ追加
+    setLogs((prev) => [
+      ...prev,
+      {
+        time,
+        drink: drinkName,
+        mode,
+        cups: mode === "preset" ? Number(cups) : undefined,
+        ml: totalMl,
+        caffeineMg,
+      },
+    ]);
+    setTime(""); // 入力欄をリセット
+
+    // 成功メッセージを一時表示
+    setSuccess("カフェイン摂取履歴を登録しました");
+    setTimeout(() => setSuccess(""), 2000);
+  };
+
+  return (
+    <div className="w-full max-w-lg mx-auto p-4 bg-white rounded-2xl shadow-md">
+      {/* 入力欄グループ */}
+      <div className="flex flex-col gap-4 mb-4">
+        <div>
+          {/* 飲料名・摂取量選択コンポーネント */}
+          <CaffeineDrinkSelect
+            drinkOptions={DRINK_OPTIONS}
+            drink={drinkName}
+            mode={mode}
+            setMode={setMode}
+            cups={cups}
+            setCups={setCups}
+            ml={ml}
+            setMl={setMl}
+            onDrinkChange={handleDrinkChange}
+          />
+        </div>
+        <div>
+          {/* 摂取時間入力 */}
+          <label className="block text-sm text-gray-600 mb-1">摂取時間</label>
+          <input
+            type="time"
+            className="w-full px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* 追加ボタン */}
+      <button
+        className="w-full mb-4 px-6 py-2 bg-blue-500 text-white font-semibold rounded-xl shadow hover:bg-blue-600 transition"
+        onClick={handleAddLog}
+        type="button"
+      >
+        追加
+      </button>
+
+      {/* エラー・成功メッセージ表示 */}
+      {error && <div className="text-red-500 text-sm mb-2">{error}</div>}
+      {success && <div className="text-green-600 text-sm mb-2">{success}</div>}
+
+      {/* 履歴テーブル表示 */}
+      <CaffeineLogTable logs={logs} />
+    </div>
+  );
+};
+
+export default CaffeineLogForm;

--- a/src/components/CaffeineLogTable.tsx
+++ b/src/components/CaffeineLogTable.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+
+// 1件の摂取記録データの型定義
+export interface CaffeineLogEntry {
+  time: string; // 摂取時間（hh:mm形式）
+  drink: string; // 飲料名
+  mode: "preset" | "custom"; // 入力モード：プリセットか任意mlか
+  cups?: number; // 杯数（プリセット時のみ）
+  ml: number; // 総摂取量（ml）
+  caffeineMg: number; // 総カフェイン量（mg）
+}
+
+// props型：摂取履歴配列
+interface Props {
+  logs: CaffeineLogEntry[];
+}
+
+// カフェイン摂取履歴テーブル本体コンポーネント
+const CaffeineLogTable: React.FC<Props> = ({ logs }) => {
+  // テーブルの開閉状態を管理
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="mt-6">
+      {/* タイトル＆開閉ボタン */}
+      <div className="flex items-center mb-2">
+        <h3 className="text-md font-semibold text-gray-700 mr-2">摂取履歴</h3>
+        <button
+          type="button"
+          className="text-blue-500 underline text-xs"
+          onClick={() => setOpen((o) => !o)} // 折り畳み/展開をトグル
+        >
+          {open ? "▲" : "▼"}
+        </button>
+      </div>
+      {/* 開いているときだけ履歴を表示 */}
+      {open &&
+        (logs.length === 0 ? (
+          // 履歴がなければメッセージ
+          <div className="text-gray-400 text-sm">まだ記録がありません。</div>
+        ) : (
+          // 履歴テーブル本体
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left py-2 text-gray-500">時間</th>
+                <th className="text-left py-2 text-gray-500">飲料名</th>
+                <th className="text-left py-2 text-gray-500">杯数/量</th>
+                <th className="text-left py-2 text-gray-500">総摂取ml</th>
+                <th className="text-left py-2 text-gray-500">
+                  カフェイン量(mg)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {/* 履歴データを1行ずつ出力 */}
+              {logs.map((log, idx) => (
+                <tr
+                  key={idx}
+                  className="border-b last:border-none text-gray-900"
+                >
+                  <td className="py-2">{log.time}</td>
+                  <td className="py-2">{log.drink}</td>
+                  <td className="py-2">
+                    {/* プリセット時は杯数、カスタム時はmlで表示 */}
+                    {log.mode === "preset"
+                      ? log.cups !== undefined
+                        ? `${log.cups}杯`
+                        : "-"
+                      : `${log.ml}ml（手入力）`}
+                  </td>
+                  <td className="py-2">{log.ml}</td>
+                  <td className="py-2">{log.caffeineMg}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ))}
+    </div>
+  );
+};
+
+export default CaffeineLogTable;

--- a/src/lib/caffeine-drink-options.ts
+++ b/src/lib/caffeine-drink-options.ts
@@ -1,0 +1,30 @@
+/**
+ * カフェイン量や1杯あたりの量がドリンクごとに定義されたデータ
+ * カフェイン量や1杯あたりの量は適当なので要修正
+ */
+
+export interface DrinkOption {
+  name: string; // 飲み物名
+  defaultMlPerCup: number; // 1杯あたりのml
+  caffeineMgPer100ml: number; // 100mlあたりカフェインmg
+  cupPresets: number[]; // 選択肢として出す杯数（例：[1,2,3]）
+  enableCustomMl?: boolean; // 任意ml入力許可（省略時true扱い）
+}
+
+export const DRINK_OPTIONS: DrinkOption[] = [
+  {
+    name: "コーヒー",
+    defaultMlPerCup: 120,
+    caffeineMgPer100ml: 67,
+    cupPresets: [1, 2, 3], // 「1杯」「2杯」「3杯」
+    enableCustomMl: true, // 任意mlも入力可能
+  },
+  {
+    name: "エナジードリンク",
+    defaultMlPerCup: 200,
+    caffeineMgPer100ml: 40,
+    cupPresets: [0.5, 1], // 「半分（0.5杯）」「1本（1杯）」
+    enableCustomMl: true,
+  },
+  // 他も同様
+];


### PR DESCRIPTION
## 概要
カフェイン摂取情報を記録・確認できる折り畳み式のフォームを実装しました。

## 変更内容
- 飲料名・摂取量（ml または 杯数）・摂取時間を入力可能なフォームを追加
- フォームは折り畳み式で、クリックにより表示の切り替えが可能
- 同一ページ内で摂取履歴も確認可能

## 補足
- ドリンクの選択肢（`lib/caffeine-drink-options.ts`）は今後拡張予定です
- 記録データの保存処理（バックエンド/API）は未実装のため、別PRにて対応が必要です

## 今後の対応
- バックエンドとの接続によるデータ登録処理の実装
- ドリンク種類の追加

## 関連Issue
Closes #19