### PR TITLE
fix/カフェイン摂取フォームのデザイン修正

### DIFF
--- a/src/components/CaffeineLogForm.tsx
+++ b/src/components/CaffeineLogForm.tsx
@@ -106,12 +106,12 @@ const CaffeineLogForm: React.FC = () => {
         <div>
           {/* 摂取時間入力 */}
           <label className="block text-sm text-gray-600 mb-1">摂取時間</label>
-            <input
-              type="time"
-              className="w-full px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900"
-              value={time}
-              onChange={(e) => setTime(e.target.value)}
-            />
+          <input
+            type="time"
+            className="w-full px-3 py-2 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-400 text-gray-900"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
         </div>
       </div>
 

--- a/src/components/CaffeineLogTable.tsx
+++ b/src/components/CaffeineLogTable.tsx
@@ -46,7 +46,9 @@ const CaffeineLogTable: React.FC<Props> = ({ logs }) => {
                 <th className="text-left py-2 text-gray-500">時間</th>
                 <th className="text-left py-2 text-gray-500">飲料名</th>
                 <th className="text-left py-2 text-gray-500">摂取量</th>
-                <th className="text-left py-2 text-gray-500">カフェイン量(mg)</th>
+                <th className="text-left py-2 text-gray-500">
+                  カフェイン量(mg)
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/src/lib/CaffeineDrinkOptions.ts
+++ b/src/lib/CaffeineDrinkOptions.ts
@@ -17,41 +17,41 @@ export const DRINK_OPTIONS: DrinkOption[] = [
     defaultMlPerCup: 200,
     caffeineMgPer100ml: 40,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
+    enableCustomMl: true,
   },
   {
     name: "エスプレッソ",
     defaultMlPerCup: 30,
     caffeineMgPer100ml: 212,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
+    enableCustomMl: true,
   },
   {
     name: "紅茶",
     defaultMlPerCup: 250,
     caffeineMgPer100ml: 20,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
+    enableCustomMl: true,
   },
   {
     name: "緑茶",
     defaultMlPerCup: 250,
     caffeineMgPer100ml: 12,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
+    enableCustomMl: true,
   },
   {
     name: "コーラ",
     defaultMlPerCup: 330,
     caffeineMgPer100ml: 10,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
+    enableCustomMl: true,
   },
   {
     name: "エナジードリンク",
     defaultMlPerCup: 250,
     caffeineMgPer100ml: 32,
     cupPresets: [1, 2, 3],
-    enableCustomMl: true
-  }
+    enableCustomMl: true,
+  },
 ];


### PR DESCRIPTION
## 変更内容
- 摂取履歴から総摂取量というカラムを削除
- カフェイン摂取記録の枠と睡眠時間の間の余白を狭めた
- 摂取時間の初期値を現在の時間に設定 