### PR TITLE
fix: 集中度グラフの最大値を100までに修正(#51)

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -43,7 +43,7 @@ const Chart: React.FC<Props> = ({ data }) => {
         >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="time" tick={{ fontSize: 12 }} minTickGap={8} />
-          <YAxis domain={[0, 120]} tick={{ fontSize: 12 }} width={28} />
+          <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} width={28} />
           <Tooltip />
           <Legend />
           <Line


### PR DESCRIPTION
## 変更内容

- 集中度グラフの上限値を100に修正


## 補足

- バックエンドでの修正が必要であれば担当を決めて修正お願いします．(@YutoShimmyo @KeitaTakeda )
  - もともと集中度の最大値が100となっており，修正が不要であればご放念ください