### PR TITLE
Fix/次カフェインの摂取時間カードと円グラフのレイアウト

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,7 +120,7 @@ const HomePage: React.FC = () => {
             </div>
 
             {/* developブランチの新しいレイアウトを採用 */}
-            <div className="w-full max-w-4xl mx-auto flex flex-row items-start justify-center gap-1 mt-8 px-0">
+            <div className="w-full max-w-2xl mx-auto flex flex-row items-start justify-center gap-1 mt-8 px-0">
               <div className="flex-1">
                 <RecommendedPlanList recommendations={recommendations} />
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,7 +120,7 @@ const HomePage: React.FC = () => {
             </div>
 
             {/* developブランチの新しいレイアウトを採用 */}
-            <div className="w-full max-w-2xl mx-auto flex flex-row items-start justify-center gap-1 mt-8 px-0">
+            <div className="w-full max-w-2xl mx-auto flex flex-row items-center justify-center gap-1 mt-8 px-0">
               <div className="flex-2">
                 <RecommendedPlanList recommendations={recommendations} />
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,7 +121,7 @@ const HomePage: React.FC = () => {
 
             {/* developブランチの新しいレイアウトを採用 */}
             <div className="w-full max-w-2xl mx-auto flex flex-row items-start justify-center gap-1 mt-8 px-0">
-              <div className="flex-1">
+              <div className="flex-2">
                 <RecommendedPlanList recommendations={recommendations} />
               </div>
               <div className="flex-1">

--- a/src/components/Summery.tsx
+++ b/src/components/Summery.tsx
@@ -32,7 +32,13 @@ const Summery: React.FC<SummeryProps> = ({ caffeineData }) => {
   }
 
   return (
-    <div className="w-full max-w-sm mx-auto p-0">
+    <div className="w-full max-w-sm mx-auto p-0 flex flex-col items-center">
+      {/*タイトル */}
+      <div className="text-xs sm:text-sm md:text-base lg:text-lg font-medium text-gray-700 mb-2 text-center">
+        カフェイン総量
+      </div>
+
+      {/* グラフ */}
       <div className="w-full h-24 md:h-32 lg:h-40">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart


### PR DESCRIPTION
## 変更内容
- カフェインの摂取時間カードと円グラフのコンポーネントの位置関係の修正
  - 横にはみ出していたので修正 
  - 垂直方向に中央揃え
- 円グラフにタイトル追加