### PR TITLE
Fix/集中力グラフのマイナー変更

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -50,7 +50,15 @@ const Chart: React.FC<Props> = ({ data }) => {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="time" tick={{ fontSize: 12 }} minTickGap={8} />
           <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} width={28} />
-          <Tooltip />
+          <Tooltip
+            contentStyle={{
+              color: "#000",
+              backgroundColor: "#fff",
+              borderRadius: "0.75rem",
+              border: "1px solid #eee",
+            }}
+            labelStyle={{ color: "#000" }} // ここでラベル（時刻）の文字色だけ黒に
+          />
           <Legend />
           <Line
             type="monotone"


### PR DESCRIPTION
## 変更内容
- 集中力チャートのグラフにカーソルをかざした際に表示される時刻の文字色を修正
  - 灰色(見づらい)→黒