### PR TITLE
Unity連携の型を作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-unity-webgl": "^9.9.0",
         "recharts": "^2.15.3"
       },
       "devDependencies": {
@@ -5367,6 +5368,25 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-unity-webgl": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/react-unity-webgl/-/react-unity-webgl-9.9.0.tgz",
+      "integrity": "sha512-oxjSiVlOkyj85p+Qq3DBQXgnEfadSHRfX1YrKn3k7/yIAraVFv3vSd9v4P2t3/pK5ZH8qMwVcGWAyHgFo3tk+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jeffreylanters"
+        },
+        {
+          "type": "website",
+          "url": "https://react-unity-webgl.dev/support"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/recharts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-unity-webgl": "^9.9.0",
     "recharts": "^2.15.3"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import Summery from "../components/Summery";
 import type { Recommendation } from "../components/NextCaffeineTime";
 import { useCaffeineAmounts } from "../hooks/UseCaffeineAmounts";
 import { useCaffeineLogs } from "@/hooks/UseCaffeineLogs";
+import { useUnityContext } from "react-unity-webgl";
 
 const HomePage: React.FC = () => {
   // developブランチの新しいカスタムフックで状態を管理
@@ -40,6 +41,12 @@ const HomePage: React.FC = () => {
   const [activeGraph, setActiveGraph] = useState<"simulation" | "current">(
     "simulation",
   );
+  const { unityProvider, sendMessage, isLoaded } = useUnityContext({
+    loaderUrl: "/unity/Build/public.loader.js", // Unityビルドファイルのパス
+    dataUrl: "/unity/Build/public.data",
+    frameworkUrl: "/unity/Build/public.framework.js",
+    codeUrl: "/unity/Build/public.wasm",
+  });
 
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [warnings, setWarnings] = useState<string[]>([]); // 警告メッセージ用のstateを追加
@@ -100,6 +107,45 @@ const HomePage: React.FC = () => {
     }
   }, [bedTime, wakeTime, focusPeriods, isValid]);
 
+  // --- 集中度をUnityに定期的に送信するuseEffectを追加 ---
+  useEffect(() => {
+    // 5秒ごとに実行するタイマー
+    const interval = setInterval(() => {
+      // Unityがロード済みで、グラフデータが存在する場合のみ実行
+      if (isLoaded && graphData.simulation.length > 0) {
+        const now = new Date();
+        const currentTimeStr = now.toLocaleTimeString("ja-JP", {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        // グラフデータから現在時刻に最も近いデータポイントを探す
+        const currentPoint = graphData.simulation.find(
+          (p) => p.time === currentTimeStr,
+        );
+
+        if (currentPoint) {
+          const concentrationValue = currentPoint.value; // 集中度の値 (0-100)
+
+          console.log(`Sending to Unity: ${concentrationValue}`); // デバッグ用
+
+          // Unityのメソッドを呼び出す
+          // 第1引数: GameObject名 ("PerformanceController")
+          // 第2引数: C#スクリプトのメソッド名 ("UpdateConcentration")
+          // 第3引数: 送信する値 (数値を文字列に変換)
+          sendMessage(
+            "PerformanceController",
+            "UpdateConcentration",
+            concentrationValue.toString(),
+          );
+        }
+      }
+    }, 5000); // 5000ms = 5秒
+
+    // コンポーネントがアンマウントされるときにタイマーをクリア
+    return () => clearInterval(interval);
+  }, [isLoaded, graphData.simulation, sendMessage]); // 依存配列に設定
+
   // handleGeneratePlan を useEffect の依存に追加
   useEffect(() => {
     const completed = localStorage.getItem("initial-setup-complete");
@@ -118,7 +164,8 @@ const HomePage: React.FC = () => {
         {!showSettingModal && (
           <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-8">
             <div className="w-full max-w-2xl flex justify-center">
-              <UnityModel />
+              {/* UnityModelにunityProviderを渡す */}
+              <UnityModel unityProvider={unityProvider} />
             </div>
 
             {/* developブランチの新しいレイアウトを採用 */}

--- a/src/components/UnityModel.tsx
+++ b/src/components/UnityModel.tsx
@@ -1,8 +1,20 @@
 "use client";
 import React from "react";
+import { Unity } from "react-unity-webgl";
+import { UnityProvider } from "react-unity-webgl/distribution/types/unity-provider";
 
-const UnityModelPlaceholder: React.FC = () => (
+interface UnityModelProps {
+  unityProvider: UnityProvider;
+}
+
+const UnityModelPlaceholder: React.FC<UnityModelProps> = ({
+  unityProvider,
+}) => (
   <div className="flex-1 bg-gray-200 rounded-2xl flex items-center justify-center h-[240px] sm:h-[320px] lg:h-[420px] text-gray-500 text-lg font-semibold border-2 border-dashed border-gray-300">
+    <Unity
+      unityProvider={unityProvider}
+      style={{ width: "100%", height: "100%" }}
+    />
     ここにUnityモデルが入ります
   </div>
 );


### PR DESCRIPTION
## 変更内容
- このPRで行った変更点の一覧:
  - 


## チェックリスト
- Unityに集中度を送るための型を作成しました。

[連携の全体像]
1.データ取得: ユーザーが「カフェイン計画を生成する」ボタンをクリックすると、page.tsxがAPI /api/plan を呼び出します。
2.データ保持: APIから返された集中度予測データ（simulationData）は、page.tsx内のgraphData stateに保存されます。
3.定期的データ送信: page.tsxで、数秒おきのタイマーを設定します。タイマーは現在の時刻に最も近い集中度データをgraphDataから探し出します。
4.Unityへ送信: react-unity-webglライブラリのsendMessage関数を使い、見つけ出した集中度の値をUnity側の特定のメソッドに送ります。
5.Unity側での反映: Unity内のC#スクリプトが値を受け取り、その値に応じて3DモデルのアニメーションやUIなどを更新します。


## 補足
- npm install react-unity-webgl
上記のライブラリを入れる必要あり
  -
