### PR TITLE
fix: 初回設定の文字色を変更

### DIFF
--- a/src/components/SettingModal.tsx
+++ b/src/components/SettingModal.tsx
@@ -65,7 +65,9 @@ const SettingModal: React.FC<SettingModalProps> = ({ onClose }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-md">
-        <h2 className="text-xl font-bold mb-4 text-center">初回設定</h2>
+        <h2 className="text-xl font-bold mb-4 text-center text-black">
+          初回設定
+        </h2>
 
         <SleepForm
           bedTime={bedTime}


### PR DESCRIPTION
## 変更内容
- モーダル画面の「初回設定」の文字色を灰色→黒に変更
  - ∵灰色だとやや見にくいと考えた
